### PR TITLE
Add Node test runner and sample test

### DIFF
--- a/client/src/__tests__/app.test.js
+++ b/client/src/__tests__/app.test.js
@@ -1,0 +1,6 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+test('basic arithmetic', () => {
+  assert.equal(1 + 1, 2);
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "npm run build:client && npm run build:server",
     "build:client": "cd client && npm install && npm run build",
     "build:server": "cd server && npm install",
-    "start": "node server/server.js"
+    "start": "node server/server.js",
+    "test": "node --test"
   },
   "engines": {
     "node": "18.x"


### PR DESCRIPTION
## Summary
- add `npm test` script using Node's built-in test runner
- create a basic arithmetic test under `client/src/__tests__`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b080502e8c83208a3a496a8e126474