### PR TITLE
Add wood waste factor setting

### DIFF
--- a/client/src/pages/settings/SettingsPage.jsx
+++ b/client/src/pages/settings/SettingsPage.jsx
@@ -24,7 +24,8 @@ const SettingsPage = () => {
       hardware: [],
       finishing: [],
       sheet: [],
-      upholsteryMaterials: []
+      upholsteryMaterials: [],
+      woodWasteFactor: ''
     },
     cnc: {
       rate: '',

--- a/server/models/CalculatorSettings.js
+++ b/server/models/CalculatorSettings.js
@@ -15,7 +15,8 @@ const calculatorSettingsSchema = new mongoose.Schema({
     hardware: { type: Array, default: [] },
     finishing: { type: Array, default: [] },
     sheet: { type: Array, default: [] },
-    upholsteryMaterials: { type: Array, default: [] }
+    upholsteryMaterials: { type: Array, default: [] },
+    woodWasteFactor: { type: Number, default: 0 }
   },
   cnc: {
     rate: { type: Number, default: 0 },


### PR DESCRIPTION
## Summary
- extend calculator settings schema with wood waste factor
- initialize wood waste factor in client settings state for editing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b086a70b888320923914e4c1f40142