### PR TITLE
handle hardware items without settings ids

### DIFF
--- a/server/services/calculationService.js
+++ b/server/services/calculationService.js
@@ -177,12 +177,22 @@ const calculateHardwareCost = (hardware, settings) => {
   
   return hardware.reduce((sum, item) => {
     const quantity = Number(item.quantity) || 0;
-    
+
     // Find the latest price from settings
     const hardwareSettings = settings?.materials?.hardware?.find(h => h.id === Number(item.hardwareId));
-    const pricePerUnit = hardwareSettings 
-      ? (Number(hardwareSettings.pricePerPack) / Number(hardwareSettings.unitsPerPack)) 
-      : (Number(item.pricePerUnit) || 0);
+    let pricePerUnit;
+
+    if (hardwareSettings) {
+      pricePerUnit = (Number(hardwareSettings.pricePerPack) / Number(hardwareSettings.unitsPerPack)) || 0;
+    } else if (item.pricePerUnit != null) {
+      pricePerUnit = Number(item.pricePerUnit) || 0;
+    } else if (item.costPerUnit != null) {
+      pricePerUnit = Number(item.costPerUnit) || 0;
+    } else if (item.cost != null && quantity > 0) {
+      pricePerUnit = Number(item.cost) / quantity;
+    } else {
+      pricePerUnit = 0;
+    }
 
     return sum + (quantity * pricePerUnit);
   }, 0);

--- a/server/services/calculationService.test.js
+++ b/server/services/calculationService.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { calculateHardwareCost, calculatePricing } = require('./calculationService');
+
+test('calculateHardwareCost falls back to costPerUnit or cost when pricePerUnit missing', () => {
+  const hardware = [
+    { quantity: 5, costPerUnit: 2 }, // 10
+    { quantity: 3, cost: 12 },       // 4 per unit -> 12
+    { quantity: 2, pricePerUnit: 1.5 } // 3
+  ];
+  const total = calculateHardwareCost(hardware, {});
+  assert.strictEqual(total, 25);
+});
+
+test('pricing sync retains hardware costs without settings ids', () => {
+  const itemData = {
+    labor: {},
+    materials: {
+      hardware: [
+        { quantity: 5, costPerUnit: 2 },
+        { quantity: 3, cost: 12 }
+      ]
+    }
+  };
+  const result = calculatePricing(itemData, {});
+  assert.strictEqual(result.materials.hardware.cost, 22);
+});


### PR DESCRIPTION
## Summary
- allow `calculateHardwareCost` to fall back to `costPerUnit` or `cost/quantity` when settings provide no price
- test hardware costs in pricing flow to ensure values persist without settings IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b089d09fb8832095d1b4f2ac3ab19e