### PR TITLE
Preserve material arrays during price sheet sync

### DIFF
--- a/server/services/calculationService.js
+++ b/server/services/calculationService.js
@@ -271,12 +271,12 @@ const calculatePricing = (itemData, settings) => {
   
   // Calculate wood materials
   const woodResult = calculateWoodCost(itemData.materials?.wood || [], settings);
-  
+
   // Calculate other material costs
-  const finishingCost = calculateFinishingCost(itemData.materials?.finishing || {});
-  const hardwareCost = calculateHardwareCost(itemData.materials?.hardware || []);
-  const upholsteryCost = calculateUpholsteryCost(itemData.materials?.upholstery || {});
-  const sheetCost = calculateSheetCost(itemData.materials?.sheet || []);
+  const finishingCost = calculateFinishingCost(itemData.materials?.finishing || {}, settings);
+  const hardwareCost = calculateHardwareCost(itemData.materials?.hardware || [], settings);
+  const upholsteryCost = calculateUpholsteryCost(itemData.materials?.upholstery || {}, settings);
+  const sheetCost = calculateSheetCost(itemData.materials?.sheet || [], settings);
   
   // Calculate CNC cost
   const cncRuntime = Number(itemData.cnc?.runtime) || 0;


### PR DESCRIPTION
## Summary
- Ensure price sheet sync preserves hardware, sheet, and wood material arrays instead of overwriting them with cost objects
- Merge recalculated material totals and computed wood costs without losing existing entries
- Pass settings into all material cost calculations for consistent pricing updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b086f84c2c8320af845e784d316d77